### PR TITLE
bugfix: division by 0 error on /products

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -59,9 +59,10 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
         total_rating = 0
+        if not ratings.exists():
+            return 0
         for rating in ratings:
             total_rating += rating.rating
-
         avg = total_rating / len(ratings)
         return avg
 


### PR DESCRIPTION
made a check with an if statement that returns 0 if there are no ratings on a product- this can be updated later to be something else but keeping it an int value seemed best.

Description of PR that completes issue here...

## Changes

- on the average rating property, there is an if statement to check if any ratings exist using the .exist() method. if no ratings exist, 0 is returned for the average rating.

## Requests / Responses

**Request**

GET `/products` lists products

**Response**

HTTP/1.1 201 OK

```json
{
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }
```

## Testing

Description of how to test code...

- [ ] GET Postman request at http://localhost:8000/products
