### PR TITLE
Bugfix/same user profile always returned

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,24 @@
         "--django-settings-module=bangazon.settings",
         "--max-line-length=120"
     ],
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#b58f01",
+        "activityBar.background": "#b58f01",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#01fec8",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#b58f01",
+        "statusBar.background": "#826701",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#b58f01",
+        "statusBarItem.remoteBackground": "#826701",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#826701",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#82670199",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.remoteColor": "#826701",
 }

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,13 +81,15 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})
 
             return Response(serializer.data)
+        except Customer.DoesNotExist:
+            return Response({'message': 'Customer profile not found'}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 


### PR DESCRIPTION
Removed hard-coded user id from list method in profile viewset module.

## Changes

- current_user for Profile class list method changed from hard-coded user id
to request.user
- added exception within Profile class list method to validate that Customer object requested exists

## Requests / Responses

**Request**

GET `/profile` returns the profile for the current authorized user

Headers:
   Authorization: Token <user's-auth-token>
   Content-Type: application/json

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/customers/4",
    "user": {
        "first_name": "Steve",
        "last_name": "Brownlee",
        "email": "steve@stevebrownlee.com"
    },
    "phone_number": "555-1212",
    "address": "100 Infinity Way",
    "payment_types": [],
    "recommends": []
}
```

## Testing

- [ ] Run migrations ( if you haven't already ) 
- [ ] Start up API in debug mode
- [ ] open Postman or similar application
- [ ] start a GET request to "http://localhost:8000/profile"
- [ ] grab an auth token from a user in the database
- [ ] pass the auth token in the header for the request