### PR TITLE
Feature/stores added models updated

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -8,23 +8,24 @@ from bangazonapi.views import *
 
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
-router.register(r'products', Products, 'product')
-router.register(r'productcategories', ProductCategories, 'productcategory')
-router.register(r'lineitems', LineItems, 'orderproduct')
-router.register(r'customers', Customers, 'customer')
-router.register(r'users', Users, 'user')
-router.register(r'orders', Orders, 'order')
-router.register(r'cart', Cart, 'cart')
-router.register(r'paymenttypes', Payments, 'payment')
-router.register(r'profile', Profile, 'profile')
+router.register(r"products", Products, "product")
+router.register(r"productcategories", ProductCategories, "productcategory")
+router.register(r"lineitems", LineItems, "orderproduct")
+router.register(r"customers", Customers, "customer")
+router.register(r"users", Users, "user")
+router.register(r"orders", Orders, "order")
+router.register(r"cart", Cart, "cart")
+router.register(r"paymenttypes", Payments, "payment")
+router.register(r"profile", Profile, "profile")
+router.register(r"stores", Stores, "store")
 
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    path('', include(router.urls)),
-    path('register', register_user),
-    path('login', login_user),
-    path('api-token-auth', obtain_auth_token),
-    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path("", include(router.urls)),
+    path("register", register_user),
+    path("login", login_user),
+    path("api-token-auth", obtain_auth_token),
+    path("api-auth", include("rest_framework.urls", namespace="rest_framework")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/fixtures/customers.json
+++ b/bangazonapi/fixtures/customers.json
@@ -1,7 +1,7 @@
 [
 {
     "model": "bangazonapi.customer",
-    "pk": 4,
+    "pk": 5,
     "fields": {
         "user": 5,
         "phone_number": "555-1212",
@@ -10,7 +10,7 @@
 },
 {
     "model": "bangazonapi.customer",
-    "pk": 5,
+    "pk": 6,
     "fields": {
         "user": 6,
         "phone_number": "555-1212",
@@ -19,7 +19,7 @@
 },
 {
     "model": "bangazonapi.customer",
-    "pk": 6,
+    "pk": 7,
     "fields": {
         "user": 7,
         "phone_number": "555-1212",
@@ -28,7 +28,7 @@
 },
 {
     "model": "bangazonapi.customer",
-    "pk": 7,
+    "pk": 8,
     "fields": {
         "user": 8,
         "phone_number": "555-1212",

--- a/bangazonapi/fixtures/order.json
+++ b/bangazonapi/fixtures/order.json
@@ -84,7 +84,7 @@
         "pk": 10,
         "model": "bangazonapi.order",
         "fields": {
-            "customer_id": 4,
+            "customer_id": 8,
             "created_date": "2018-11-03",
             "payment_type_id": null
         }

--- a/bangazonapi/fixtures/order_product.json
+++ b/bangazonapi/fixtures/order_product.json
@@ -4,7 +4,7 @@
         "pk": 1,
         "fields": {
             "order_id": 9,
-            "product_id": 1
+            "product_id": 100
         }
     },
     {
@@ -12,7 +12,7 @@
         "pk": 2,
         "fields": {
             "order_id": 10,
-            "product_id": 3
+            "product_id": 101
         }
     },
     {
@@ -20,7 +20,7 @@
         "pk": 3,
         "fields": {
             "order_id": 8,
-            "product_id": 21
+            "product_id": 102
         }
     },
     {
@@ -28,7 +28,7 @@
         "pk": 7,
         "fields": {
             "order_id": 8,
-            "product_id": 5
+            "product_id": 103
         }
     },
     {
@@ -36,7 +36,7 @@
         "pk": 4,
         "fields": {
             "order_id": 2,
-            "product_id": 52
+            "product_id": 104
         }
     },
     {
@@ -44,7 +44,7 @@
         "pk": 5,
         "fields": {
             "order_id": 2,
-            "product_id": 33
+            "product_id": 105
         }
     },
     {
@@ -52,7 +52,7 @@
         "pk": 6,
         "fields": {
             "order_id": 2,
-            "product_id": 71
+            "product_id": 106
         }
     },
     {
@@ -60,7 +60,7 @@
         "pk": 7,
         "fields": {
             "order_id": 3,
-            "product_id": 50
+            "product_id": 107
         }
     },
     {
@@ -68,7 +68,7 @@
         "pk": 8,
         "fields": {
             "order_id": 3,
-            "product_id": 50
+            "product_id": 108
         }
     },
     {
@@ -76,7 +76,7 @@
         "pk": 9,
         "fields": {
             "order_id": 3,
-            "product_id": 45
+            "product_id": 109
         }
     }
 ]

--- a/bangazonapi/fixtures/product.json
+++ b/bangazonapi/fixtures/product.json
@@ -1,1480 +1,10 @@
 [
     {
         "model": "bangazonapi.product",
-        "pk": 1,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Seoul",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 2,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 3,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Seoul",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 4,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 5,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Seoul",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 6,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 7,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Seoul",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 8,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 9,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Seoul",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 10,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 11,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 12,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 13,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 14,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 15,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 16,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 17,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 18,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Vienna",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 19,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 20,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 21,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 22,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 23,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 24,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 25,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 26,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 27,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 28,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 29,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 30,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Paris",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 31,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 32,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 33,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 34,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 35,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 36,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 37,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 38,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 39,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 40,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 41,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "New York",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 42,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 43,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Toronto",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 44,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 45,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Toronto",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 46,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 47,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Toronto",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 48,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 49,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "Toronto",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 50,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 51,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 52,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 53,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 54,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 55,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 56,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 57,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 58,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 59,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 60,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 61,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 62,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Berlin",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 63,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 64,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 65,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 66,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 67,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 68,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 69,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 70,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 71,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 72,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 73,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 74,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 75,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 76,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 77,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 78,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 79,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 80,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 81,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 82,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 83,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 84,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 85,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 86,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 87,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 88,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 89,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 90,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 91,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 92,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 93,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 94,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 95,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 96,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 97,
-        "fields": {
-            "name": "Optima",
-            "customer_id": 7,
-            "price": 1655.15,
-            "description": "2008 Kia",
-            "quantity": 3,
-            "created_date": "2019-05-21",
-            "category_id": 2,
-            "location": "London",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
-        "pk": 98,
-        "fields": {
-            "name": "Golf",
-            "customer_id": 4,
-            "price": 653.59,
-            "description": "1994 Volkswagen",
-            "quantity": 4,
-            "created_date": "2019-07-10",
-            "category_id": 2,
-            "location": "Moscow",
-            "image_path": "products/vehicle.png"
-        }
-    },
-    {
-        "model": "bangazonapi.product",
         "pk": 99,
         "fields": {
             "name": "Optima",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 1655.15,
             "description": "2008 Kia",
             "quantity": 3,
@@ -1489,7 +19,7 @@
         "pk": 100,
         "fields": {
             "name": "Golf",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 653.59,
             "description": "1994 Volkswagen",
             "quantity": 4,
@@ -1504,7 +34,7 @@
         "pk": 101,
         "fields": {
             "name": "Scarf",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 199.26,
             "description": "Woolen scarf for cold weather",
             "quantity": 9,
@@ -1519,7 +49,7 @@
         "pk": 102,
         "fields": {
             "name": "Shorts",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 139.25,
             "description": "Athletic shorts for running",
             "quantity": 2,
@@ -1534,7 +64,7 @@
         "pk": 103,
         "fields": {
             "name": "Hat",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 65.77,
             "description": "A stylish baseball cap",
             "quantity": 3,
@@ -1549,7 +79,7 @@
         "pk": 104,
         "fields": {
             "name": "T-Shirt",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 194.66,
             "description": "A comfortable cotton t-shirt",
             "quantity": 3,
@@ -1564,7 +94,7 @@
         "pk": 105,
         "fields": {
             "name": "Socks",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 125.7,
             "description": "Pack of 5 cotton socks",
             "quantity": 3,
@@ -1579,7 +109,7 @@
         "pk": 106,
         "fields": {
             "name": "Sweater",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 191.16,
             "description": "A warm, knitted sweater",
             "quantity": 9,
@@ -1594,7 +124,7 @@
         "pk": 107,
         "fields": {
             "name": "Dress",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 102.84,
             "description": "Elegant evening dress",
             "quantity": 2,
@@ -1609,7 +139,7 @@
         "pk": 108,
         "fields": {
             "name": "Socks",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 21.01,
             "description": "Pack of 5 cotton socks",
             "quantity": 10,
@@ -1624,7 +154,7 @@
         "pk": 109,
         "fields": {
             "name": "Jeans",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 165.04,
             "description": "Blue denim jeans, classic fit",
             "quantity": 9,
@@ -1639,7 +169,7 @@
         "pk": 110,
         "fields": {
             "name": "Sweater",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 189.9,
             "description": "A warm, knitted sweater",
             "quantity": 3,
@@ -1654,7 +184,7 @@
         "pk": 111,
         "fields": {
             "name": "Shorts",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 90.4,
             "description": "Athletic shorts for running",
             "quantity": 4,
@@ -1669,7 +199,7 @@
         "pk": 112,
         "fields": {
             "name": "Socks",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 199.08,
             "description": "Pack of 5 cotton socks",
             "quantity": 6,
@@ -1684,7 +214,7 @@
         "pk": 113,
         "fields": {
             "name": "Shorts",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 32.99,
             "description": "Athletic shorts for running",
             "quantity": 4,
@@ -1699,7 +229,7 @@
         "pk": 114,
         "fields": {
             "name": "Hat",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 121.78,
             "description": "A stylish baseball cap",
             "quantity": 4,
@@ -1714,7 +244,7 @@
         "pk": 115,
         "fields": {
             "name": "T-Shirt",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 144.49,
             "description": "A comfortable cotton t-shirt",
             "quantity": 1,
@@ -1729,7 +259,7 @@
         "pk": 116,
         "fields": {
             "name": "Jeans",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 173.33,
             "description": "Blue denim jeans, classic fit",
             "quantity": 2,
@@ -1744,7 +274,7 @@
         "pk": 117,
         "fields": {
             "name": "Socks",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 50.7,
             "description": "Pack of 5 cotton socks",
             "quantity": 3,
@@ -1759,7 +289,7 @@
         "pk": 118,
         "fields": {
             "name": "Jacket",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 163.42,
             "description": "Water-resistant outdoor jacket",
             "quantity": 4,
@@ -1774,7 +304,7 @@
         "pk": 119,
         "fields": {
             "name": "Jeans",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 77.32,
             "description": "Blue denim jeans, classic fit",
             "quantity": 7,
@@ -1789,7 +319,7 @@
         "pk": 120,
         "fields": {
             "name": "T-Shirt",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 21.52,
             "description": "A comfortable cotton t-shirt",
             "quantity": 6,
@@ -1804,7 +334,7 @@
         "pk": 121,
         "fields": {
             "name": "Jacket",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 46.14,
             "description": "Water-resistant outdoor jacket",
             "quantity": 5,
@@ -1819,7 +349,7 @@
         "pk": 122,
         "fields": {
             "name": "Scarf",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 62.92,
             "description": "Woolen scarf for cold weather",
             "quantity": 4,
@@ -1834,7 +364,7 @@
         "pk": 123,
         "fields": {
             "name": "Gloves",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 28.6,
             "description": "Leather gloves with touchscreen compatibility",
             "quantity": 9,
@@ -1849,7 +379,7 @@
         "pk": 124,
         "fields": {
             "name": "Jeans",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 41.6,
             "description": "Blue denim jeans, classic fit",
             "quantity": 8,
@@ -1864,7 +394,7 @@
         "pk": 125,
         "fields": {
             "name": "Jacket",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 181.46,
             "description": "Water-resistant outdoor jacket",
             "quantity": 3,
@@ -1879,7 +409,7 @@
         "pk": 131,
         "fields": {
             "name": "Pliers",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 306.81,
             "description": "Heavy-duty pliers for gripping and bending materials",
             "quantity": 6,
@@ -1894,7 +424,7 @@
         "pk": 132,
         "fields": {
             "name": "Level",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 141.13,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 4,
@@ -1909,7 +439,7 @@
         "pk": 133,
         "fields": {
             "name": "Pliers",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 490.63,
             "description": "Heavy-duty pliers for gripping and bending materials",
             "quantity": 3,
@@ -1924,7 +454,7 @@
         "pk": 134,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 524.87,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 3,
@@ -1939,7 +469,7 @@
         "pk": 135,
         "fields": {
             "name": "Wrench Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 79.53,
             "description": "A complete set of combination wrenches",
             "quantity": 3,
@@ -1954,7 +484,7 @@
         "pk": 136,
         "fields": {
             "name": "Pliers",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 547.31,
             "description": "Heavy-duty pliers for gripping and bending materials",
             "quantity": 5,
@@ -1969,7 +499,7 @@
         "pk": 137,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 424.57,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 2,
@@ -1984,7 +514,7 @@
         "pk": 138,
         "fields": {
             "name": "Electric Drill",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 63.19,
             "description": "A powerful electric drill with variable speed control",
             "quantity": 3,
@@ -1999,7 +529,7 @@
         "pk": 139,
         "fields": {
             "name": "Wrench Set",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 352.65,
             "description": "A complete set of combination wrenches",
             "quantity": 2,
@@ -2014,7 +544,7 @@
         "pk": 140,
         "fields": {
             "name": "Screwdriver Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 414.84,
             "description": "A set of flathead and Phillips head screwdrivers",
             "quantity": 3,
@@ -2029,7 +559,7 @@
         "pk": 141,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 541.9,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 10,
@@ -2044,7 +574,7 @@
         "pk": 142,
         "fields": {
             "name": "Circular Saw",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 304.44,
             "description": "A handheld circular saw for cutting wood",
             "quantity": 5,
@@ -2059,7 +589,7 @@
         "pk": 143,
         "fields": {
             "name": "Circular Saw",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 367.54,
             "description": "A handheld circular saw for cutting wood",
             "quantity": 5,
@@ -2074,7 +604,7 @@
         "pk": 144,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 200.55,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 5,
@@ -2089,7 +619,7 @@
         "pk": 145,
         "fields": {
             "name": "Electric Drill",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 335.56,
             "description": "A powerful electric drill with variable speed control",
             "quantity": 9,
@@ -2104,7 +634,7 @@
         "pk": 146,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 413.55,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 3,
@@ -2119,7 +649,7 @@
         "pk": 147,
         "fields": {
             "name": "Hammer",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 139.38,
             "description": "A durable steel hammer for carpentry",
             "quantity": 2,
@@ -2134,7 +664,7 @@
         "pk": 148,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 299.82,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 1,
@@ -2149,7 +679,7 @@
         "pk": 149,
         "fields": {
             "name": "Pliers",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 388.07,
             "description": "Heavy-duty pliers for gripping and bending materials",
             "quantity": 6,
@@ -2164,7 +694,7 @@
         "pk": 140,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 505.81,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 6,
@@ -2179,7 +709,7 @@
         "pk": 141,
         "fields": {
             "name": "Level",
-            "customer_id": 4,
+            "store_id": 8,
             "price": 298.37,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 10,
@@ -2194,7 +724,7 @@
         "pk": 142,
         "fields": {
             "name": "Chisel Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 169.76,
             "description": "A set of wood chisels for carving and shaping",
             "quantity": 4,
@@ -2209,7 +739,7 @@
         "pk": 143,
         "fields": {
             "name": "Circular Saw",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 190.34,
             "description": "A handheld circular saw for cutting wood",
             "quantity": 6,
@@ -2224,7 +754,7 @@
         "pk": 144,
         "fields": {
             "name": "Wrench Set",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 431.15,
             "description": "A complete set of combination wrenches",
             "quantity": 7,
@@ -2239,7 +769,7 @@
         "pk": 145,
         "fields": {
             "name": "Chisel Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 200.17,
             "description": "A set of wood chisels for carving and shaping",
             "quantity": 5,
@@ -2254,7 +784,7 @@
         "pk": 146,
         "fields": {
             "name": "Utility Knife",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 5.58,
             "description": "A sharp utility knife with replaceable blades",
             "quantity": 3,
@@ -2269,7 +799,7 @@
         "pk": 147,
         "fields": {
             "name": "Wrench Set",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 359.47,
             "description": "A complete set of combination wrenches",
             "quantity": 6,
@@ -2284,7 +814,7 @@
         "pk": 148,
         "fields": {
             "name": "Wrench Set",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 25.34,
             "description": "A complete set of combination wrenches",
             "quantity": 9,
@@ -2299,7 +829,7 @@
         "pk": 149,
         "fields": {
             "name": "Level",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 5.68,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 6,
@@ -2314,7 +844,7 @@
         "pk": 140,
         "fields": {
             "name": "Level",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 161.68,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 4,
@@ -2329,7 +859,7 @@
         "pk": 141,
         "fields": {
             "name": "Chisel Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 107.36,
             "description": "A set of wood chisels for carving and shaping",
             "quantity": 10,
@@ -2344,7 +874,7 @@
         "pk": 142,
         "fields": {
             "name": "Level",
-            "customer_id": 6,
+            "store_id": 6,
             "price": 146.9,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 3,
@@ -2359,7 +889,7 @@
         "pk": 143,
         "fields": {
             "name": "Level",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 131.87,
             "description": "A 24-inch level for ensuring straight lines and level surfaces",
             "quantity": 10,
@@ -2374,7 +904,7 @@
         "pk": 144,
         "fields": {
             "name": "Hammer",
-            "customer_id": 5,
+            "store_id": 5,
             "price": 383.88,
             "description": "A durable steel hammer for carpentry",
             "quantity": 4,
@@ -2389,7 +919,7 @@
         "pk": 145,
         "fields": {
             "name": "Screwdriver Set",
-            "customer_id": 7,
+            "store_id": 7,
             "price": 151.42,
             "description": "A set of flathead and Phillips head screwdrivers",
             "quantity": 6,

--- a/bangazonapi/fixtures/productrating.json
+++ b/bangazonapi/fixtures/productrating.json
@@ -3,8 +3,8 @@
         "model": "bangazonapi.productrating",
         "pk": 1,
         "fields": {
-            "product": 50,
-            "customer": 4,
+            "product": 100,
+            "customer": 8,
             "rating": 4
         }
     },
@@ -12,7 +12,7 @@
         "model": "bangazonapi.productrating",
         "pk": 2,
         "fields": {
-            "product": 50,
+            "product": 101,
             "customer": 5,
             "rating": 3
         }
@@ -21,7 +21,7 @@
         "model": "bangazonapi.productrating",
         "pk": 3,
         "fields": {
-            "product": 50,
+            "product": 102,
             "customer": 6,
             "rating": 5
         }
@@ -30,7 +30,7 @@
         "model": "bangazonapi.productrating",
         "pk": 4,
         "fields": {
-            "product": 50,
+            "product": 103,
             "customer": 7,
             "rating": 1
         }

--- a/bangazonapi/fixtures/stores.json
+++ b/bangazonapi/fixtures/stores.json
@@ -1,16 +1,6 @@
 [
     {
         "model": "bangazonapi.store",
-        "pk": 4,
-        "fields": {
-            "name": "Store for User 4",
-            "description": "Default description",
-            "seller": 4,
-            "created_date": "2024-06-22T00:00:00Z"
-        }
-    },
-    {
-        "model": "bangazonapi.store",
         "pk": 5,
         "fields": {
             "name": "Store for User 5",
@@ -36,6 +26,16 @@
             "name": "Store for User 7",
             "description": "Default description",
             "seller": 7,
+            "created_date": "2024-06-22T00:00:00Z"
+        }
+    },
+    {
+        "model": "bangazonapi.store",
+        "pk": 8,
+        "fields": {
+            "name": "Store for User 8",
+            "description": "Default description",
+            "seller": 8,
             "created_date": "2024-06-22T00:00:00Z"
         }
     }

--- a/bangazonapi/fixtures/stores.json
+++ b/bangazonapi/fixtures/stores.json
@@ -1,0 +1,42 @@
+[
+    {
+        "model": "bangazonapi.store",
+        "pk": 4,
+        "fields": {
+            "name": "Store for User 4",
+            "description": "Default description",
+            "seller": 4,
+            "created_date": "2024-06-22T00:00:00Z"
+        }
+    },
+    {
+        "model": "bangazonapi.store",
+        "pk": 5,
+        "fields": {
+            "name": "Store for User 5",
+            "description": "Default description",
+            "seller": 5,
+            "created_date": "2024-06-22T00:00:00Z"
+        }
+    },
+    {
+        "model": "bangazonapi.store",
+        "pk": 6,
+        "fields": {
+            "name": "Store for User 6",
+            "description": "Default description",
+            "seller": 6,
+            "created_date": "2024-06-22T00:00:00Z"
+        }
+    },
+    {
+        "model": "bangazonapi.store",
+        "pk": 7,
+        "fields": {
+            "name": "Store for User 7",
+            "description": "Default description",
+            "seller": 7,
+            "created_date": "2024-06-22T00:00:00Z"
+        }
+    }
+]

--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -8,3 +8,4 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+from .store import Store

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -6,25 +6,41 @@ from .customer import Customer
 from .productcategory import ProductCategory
 from .orderproduct import OrderProduct
 from .productrating import ProductRating
+from .store import Store
 
 
 class Product(SafeDeleteModel):
 
     _safedelete_policy = SOFT_DELETE
-    name = models.CharField(max_length=50,)
-    customer = models.ForeignKey(
-        Customer, on_delete=models.DO_NOTHING, related_name='products')
+    name = models.CharField(
+        max_length=50,
+    )
+    store = models.ForeignKey(
+        Store, on_delete=models.DO_NOTHING, related_name="products"
+    )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
-    description = models.CharField(max_length=255,)
-    quantity = models.IntegerField(validators=[MinValueValidator(0)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+    )
+    description = models.CharField(
+        max_length=255,
+    )
+    quantity = models.IntegerField(
+        validators=[MinValueValidator(0)],
+    )
     created_date = models.DateField(auto_now_add=True)
     category = models.ForeignKey(
-        ProductCategory, on_delete=models.DO_NOTHING, related_name='products')
-    location = models.CharField(max_length=50,)
+        ProductCategory, on_delete=models.DO_NOTHING, related_name="products"
+    )
+    location = models.CharField(
+        max_length=50,
+    )
     image_path = models.ImageField(
-        upload_to='products', height_field=None,
-        width_field=None, max_length=None, null=True)
+        upload_to="products",
+        height_field=None,
+        width_field=None,
+        max_length=None,
+        null=True,
+    )
 
     @property
     def number_sold(self):
@@ -34,7 +50,8 @@ class Product(SafeDeleteModel):
             int -- Number items on completed orders
         """
         sold = OrderProduct.objects.filter(
-            product=self, order__payment_type__isnull=False)
+            product=self, order__payment_type__isnull=False
+        )
         return sold.count()
 
     @property
@@ -67,5 +84,5 @@ class Product(SafeDeleteModel):
         return avg
 
     class Meta:
-        verbose_name = ("product")
-        verbose_name_plural = ("products")
+        verbose_name = "product"
+        verbose_name_plural = "products"

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,0 +1,13 @@
+from django.db import models
+from .customer import Customer
+from django.contrib.auth.models import User
+
+
+class Store(models.Model):
+    name = models.CharField(max_length=255)
+    description = models.TextField()
+    seller = models.ForeignKey(User, on_delete=models.CASCADE)
+    created_date = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.name

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .store import Stores

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+from rest_framework.viewsets import ViewSet
+from bangazonapi.models import Store, Product
+from rest_framework.response import Response
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = [
+            "id",  # Add this field
+            "username",
+            "email",
+            "first_name",
+            "last_name",
+        ]  # Add other fields as needed
+
+
+class StoreSerializer(serializers.ModelSerializer):
+    seller = UserSerializer(read_only=True)
+    product_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Store
+        fields = ["id", "name", "description", "seller", "product_count"]
+
+    def get_product_count(self, obj):
+        return Product.objects.filter(store=obj).count()
+
+
+class Stores(ViewSet):
+
+    def list(self, request):
+        stores = Store.objects.all()
+        serializer = StoreSerializer(stores, many=True, context={"request": request})
+        return Response(serializer.data)

--- a/seed_data.sh
+++ b/seed_data.sh
@@ -7,6 +7,7 @@ python manage.py migrate
 python manage.py loaddata users
 python manage.py loaddata tokens
 python manage.py loaddata customers
+python manage.py loaddata stores
 python manage.py loaddata product_category
 python manage.py loaddata product
 python manage.py loaddata productrating


### PR DESCRIPTION

## Ticket:

36


## What Changed:

Added full logic for Stores to exit int database

added stores model, adjusted products model to take store_id instead of customer_id

deleted duplicate fixtures

changed fixtures to accomodate only existing products


**Testing Steps:**

pull down both api, and client repos.

*******in api side immediatley reset your database with ./seed_data.sh*****

open bangazon. you should be able to see all products list when clicking products tab.

open stores tab. you should see all stores, click view products, this should create a dropdown of all the items in that store. this grid still needs to be stylized better, but theres some learning to do with how next.js handles layouts or whatever is giong on there, that i've broken off into a separate ticket.
