### PR TITLE
Bugfix: All payment types being returned

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,15 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        try:
+            customer = Customer.objects.get(user=request.auth.user)
 
-        customer_id = self.request.query_params.get('customer', None)
+            payment_types = Payment.objects.filter(customer=customer)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
-
-        serializer = PaymentSerializer(
-            payment_types, many=True, context={'request': request})
-        return Response(serializer.data)
+            serializer = PaymentSerializer(
+                payment_types, many=True, context={'request': request})
+            
+            return Response(serializer.data)
+        
+        except Customer.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
For the bug that all payments were being returned.

##Changes##

list instance in Payments view has a try/except statement for check for the Customer, then filtering the payment instead of getting all payments from the get go.

##Testing##

[ ] Run http://localhost:8000/paymenttypes on Postman with different tokens