### PR TITLE
Bugfix/store model switch user to customer

### DIFF
--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,12 +1,11 @@
 from django.db import models
 from .customer import Customer
-from django.contrib.auth.models import User
 
 
 class Store(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField()
-    seller = models.ForeignKey(User, on_delete=models.CASCADE)
+    seller = models.ForeignKey(Customer, on_delete=models.CASCADE)
     created_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,37 +1,36 @@
 from rest_framework import serializers
+from django.db.models import Count
 from django.contrib.auth.models import User
+from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from bangazonapi.models import Store, Product
-from rest_framework.response import Response
 
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
-            "id",  # Add this field
+            "id",
             "username",
             "email",
             "first_name",
             "last_name",
-        ]  # Add other fields as needed
+        ]
 
 
 class StoreSerializer(serializers.ModelSerializer):
-    seller = UserSerializer(read_only=True)
-    product_count = serializers.SerializerMethodField()
+    seller = UserSerializer(source="seller.user", read_only=True)
+    product_count = serializers.IntegerField()
 
     class Meta:
         model = Store
         fields = ["id", "name", "description", "seller", "product_count"]
 
-    def get_product_count(self, obj):
-        return Product.objects.filter(store=obj).count()
-
 
 class Stores(ViewSet):
-
     def list(self, request):
-        stores = Store.objects.all()
+        stores = Store.objects.select_related("seller__user").annotate(
+            product_count=Count("products")
+        )
         serializer = StoreSerializer(stores, many=True, context={"request": request})
         return Response(serializer.data)

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -29,8 +29,6 @@ class StoreSerializer(serializers.ModelSerializer):
 
 class Stores(ViewSet):
     def list(self, request):
-        stores = Store.objects.select_related("seller__user").annotate(
-            product_count=Count("products")
-        )
+        stores = Store.objects.annotate(product_count=Count("products"))
         serializer = StoreSerializer(stores, many=True, context={"request": request})
         return Response(serializer.data)


### PR DESCRIPTION
Ticket##
#48 

what changed##
updated the Store model to have the seller field point to the Customer table instead of the User table. The seller field is now a ForeignKey to the Customer model.

Store view refactored to use .annotate instead of having python count objects.

how to test##

run a GET request to /stores, verify correct seller is nested in your response objects, and product_count reflects the amount of products in that store.