### PR TITLE
Like decorators added to products view

### DIFF
--- a/bangazonapi/views/like.py
+++ b/bangazonapi/views/like.py
@@ -18,28 +18,6 @@ class Likes(viewsets.ModelViewSet):
     queryset = Like.objects.all()
     serializer_class = LikeSerializer
 
-    def create(self, request):
-        """Handle POST operations to like or unlike a product"""
-        customer = Customer.objects.get(user=request.auth.user)
-        product = Product.objects.get(pk=request.data["product_id"])
-
-        # Check if the like already exists
-        existing_like = Like.objects.filter(customer=customer, product=product).first()
-
-        if existing_like:
-            # If like exists, delete it (unlike)
-            existing_like.delete()
-            return Response(
-                {"message": "Like removed"}, status=status.HTTP_204_NO_CONTENT
-            )
-        else:
-            # If like does not exist, create it
-            like = Like.objects.create(customer=customer, product=product)
-            like.save()
-            serializer = LikeSerializer(like, context={"request": request})
-
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-
     def list(self, request):
         """Handle GET requests to get all likes by the authenticated user"""
 
@@ -63,18 +41,3 @@ class Likes(viewsets.ModelViewSet):
         serializer = LikeSerializer(likes, many=True, context={"request": request})
 
         return Response(serializer.data)
-
-    def destroy(self, request, pk=None):
-        """Handle DELETE requests to unlike a product"""
-        try:
-            like = Like.objects.get(pk=pk, customer__user=request.auth.user)
-            like.delete()
-            return Response(None, status=status.HTTP_204_NO_CONTENT)
-
-        except Like.DoesNotExist as ex:
-            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-
-        except Exception as ex:
-            return Response(
-                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from bangazonapi.models import Product, Customer, ProductCategory
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
+from bangazonapi.models import Like
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -264,7 +265,6 @@ class Products(ViewSet):
 
         store = self.request.query_params.get("store", None)
 
-        
         # Support filtering by category and/or quantity
         category = self.request.query_params.get("category", None)
         quantity = self.request.query_params.get("quantity", None)
@@ -295,7 +295,6 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
-                    
 
         if store is not None:
             products = products.filter(store__id=store)
@@ -305,7 +304,7 @@ class Products(ViewSet):
         )
         return Response(serializer.data)
 
-    @action(methods=["post"], detail=True)
+    @action(methods=["post"], detail=True, url_path="recommend")
     def recommend(self, request, pk=None):
         """Recommend products to other users"""
 
@@ -320,3 +319,44 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(detail=True, methods=["post"], url_path="like")
+    def like_product(self, request, pk=None):
+        customer = Customer.objects.get(user=request.auth.user)
+        product = Product.objects.get(pk=pk)
+        like, created = Like.objects.get_or_create(customer=customer, product=product)
+
+        if created:
+            return Response(
+                {"message": "Product liked"}, status=status.HTTP_201_CREATED
+            )
+        else:
+            return Response(
+                {"message": "Product already liked"}, status=status.HTTP_200_OK
+            )
+
+    # Custom action to unlike a product
+    @action(detail=True, methods=["delete"], url_path="unlike")
+    def unlike_product(self, request, pk=None):
+        customer = Customer.objects.get(user=request.auth.user)
+        try:
+            like = Like.objects.get(customer=customer, product__pk=pk)
+            like.delete()
+            return Response(
+                {"message": "Like removed"}, status=status.HTTP_204_NO_CONTENT
+            )
+        except Like.DoesNotExist:
+            return Response(
+                {"message": "Like not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+    # Custom action to get all liked products
+    @action(detail=False, methods=["get"], url_path="liked")
+    def liked_products(self, request):
+        customer = Customer.objects.get(user=request.auth.user)
+        likes = Like.objects.filter(customer=customer)
+        products = [like.product for like in likes]
+        serializer = ProductSerializer(
+            products, many=True, context={"request": request}
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## TICKET
#17 

## WHAT CHANGED

added decorators to the products view pertaining to likes, create/destroy a like, and list all your liked products.

## HOW TO TEST


CREATE LIKE
with valid auth heading on, run a POST to /products/(pk for product)/like

example /products/101/like

if there is no like already on that object you will get a 204 and a message saying "like created" 
if a like already exists you will get a 200 back saying "product already liked"

DELETE LIKE
with valid auth heading on, run a DELETE to /products/(pk for product)/unlike
***notice the last param in the url path is unlike now***
example /products/101/unlike

if a like existed and was deleted you will get a 204 back with a message "Like removed"
if no like existed a 404, and "like not found"


LIST
with valid auth heading on 
run a GET to /products/liked
all liked products for logged in user should be returned.


