### PR TITLE
Bugfix/cant remove item from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import OrderProduct, Order, Product, Customer
 from bangazonapi.views.product import ProductSerializer
+from rest_framework.permissions import IsAuthenticated
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
@@ -48,6 +49,7 @@ class LineItems(ViewSet):
     #   attribute on this field.
     # queryset = OrderProduct.objects.all()
 
+    permission_classes = [IsAuthenticated]
 
     def retrieve(self, request, pk=None):
         """
@@ -77,7 +79,7 @@ class LineItems(ViewSet):
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /lineitems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 
@@ -92,6 +94,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -99,7 +99,7 @@ class LineItems(ViewSet):
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({'message': 'Order product not found'}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Customers were complaining that they can't remove an item from the cart after it has been added. These changes allow a customer to perform a DELETE request to `/lineitems/{pk}` to remove a specified item from their cart.

## Changes

- added a Django isAuthenticated permission to the LineItems viewset class
- added logic for destroy method within the LineItems viewset class

## Requests / Responses

**Request**

DELETE `/lineitems/{pk}` removes an order product (line item) from the customers cart

**Response**

HTTP 204 No Content

## Testing

- [ ] Run migrations
- [ ] Start API in debug mode
- [ ] Open Postman or similar application
- [ ] Start a DELETE operation to `http://localhost:8000/lineitems`
- [ ] Grab an auth token for a registered user that currently has at least one item in their cart
- [ ] Place the auth token in the header of the request
- [ ] Find the line item id of the item in the cart you wish to remove
- [ ] Submit the DELETE request to `http://localhost:8000/lineitems/{line item id to be removed}` (exclude curly braces) ex. `http://localhost:8000/lineitems/18` 

## Related Issues

- Fixes #34 