### PR TITLE
BUG: complete order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -2,6 +2,7 @@
 import datetime
 from django.http import HttpResponseServerError
 from django.db.models import Sum, F
+from django.shortcuts import get_object_or_404
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -120,8 +121,12 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
-        order.save()
+
+        payment_type_id = request.data.get("payment_type")
+        if payment_type_id:
+            payment = get_object_or_404(Payment, pk=payment_type_id)
+            order.payment_type = payment
+            order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Previously a payment object was expected but the id was the only thing being saved under order update, causing a bug with completing an order

## Changes

- save obj to payment type instead of id

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

PUT `/orders/8` Completes an order

```json
{
    "payment_type": 10
}
```

**Response**

HTTP/1.1 204 No Content

## Testing

Description of how to test code...

- [ ] Pull code
- [ ] Run postman with the id of an open order


## Related Issues

- Fixes #33 